### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/data/config.php
+++ b/data/config.php
@@ -29,7 +29,7 @@ class config{
         // Redirect Minecraft Fandom to new official wiki
         "/^https?:\/\/minecraft.fandom.com\/wiki\/(.*)$/i" => "https://minecraft.wiki/w/$1",
         // Redirect old nix wiki to new nix wiki
-        "/^https?:\/\/nixos.wiki\/(.*)$/i" => "https://wiki.nixos.org/$1",
+        "/^https?:\/\/wiki.nixos.org\/(.*)$/i" => "https://wiki.nixos.org/$1",
     ];
 	
 	// Enable the API?


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️